### PR TITLE
chore: add timezone support and clean up configuration files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-﻿# ===========================================
+# ===========================================
 # Hytale Server Configuration
 # ===========================================
 # Copy this file to .env and modify values
@@ -28,6 +28,8 @@ PANEL_PASS=admin
 
 # --- Panel Settings ---
 PANEL_PORT=3000
+# Timezone for container logs (e.g., America/Chicago, Europe/London)
+# TZ=UTC
 CONTAINER_NAME=hytale-server
 BASE_PATH=/
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -11,6 +11,7 @@ services:
       - "${PANEL_PORT:-3000}:3000"
       - "5173:5173"
     environment:
+      TZ: ${TZ:-UTC}
       PANEL_PORT: 3000
       PANEL_USER: ${PANEL_USER:-admin}
       PANEL_PASS: ${PANEL_PASS:-admin}

--- a/panel/Dockerfile
+++ b/panel/Dockerfile
@@ -31,8 +31,8 @@ RUN pnpm install --prod
 FROM node:25-alpine
 WORKDIR /app
 
-# Install docker CLI for docker-compose commands
-RUN apk add --no-cache docker-cli docker-cli-compose
+# Install docker CLI and tzdata for timezone support
+RUN apk add --no-cache docker-cli docker-cli-compose tzdata
 
 COPY --from=backend-deps /app/backend/node_modules ./backend/node_modules
 COPY --from=backend-build /app/backend/dist ./backend/dist

--- a/panel/Dockerfile.dev
+++ b/panel/Dockerfile.dev
@@ -3,8 +3,8 @@ FROM node:25-alpine
 
 RUN npm install -g pnpm
 
-# Install docker CLI for docker-compose commands
-RUN apk add --no-cache docker-cli docker-cli-compose
+# Install docker CLI and tzdata for timezone support
+RUN apk add --no-cache docker-cli docker-cli-compose tzdata
 
 WORKDIR /app
 

--- a/panel/backend/src/config/index.ts
+++ b/panel/backend/src/config/index.ts
@@ -3,6 +3,7 @@ import crypto from 'node:crypto';
 const defaultSecret = crypto.randomBytes(32).toString('hex');
 
 export interface Config {
+  timezone: string;
   container: {
     name: string;
   };
@@ -44,6 +45,7 @@ export interface Config {
 }
 
 const config: Config = {
+  timezone: process.env.TZ || 'UTC',
   container: {
     name: process.env.CONTAINER_NAME || 'hytale-server'
   },

--- a/panel/backend/src/services/servers.ts
+++ b/panel/backend/src/services/servers.ts
@@ -102,7 +102,7 @@ function generateDockerCompose(server: Server): string {
     ports:
       - "${server.port}:${server.port}/udp"
     environment:
-      TZ: UTC
+      TZ: ${config.timezone}
       JAVA_XMS: ${server.config.javaXms}
       JAVA_XMX: ${server.config.javaXmx}
       BIND_PORT: ${server.port}


### PR DESCRIPTION
## Description
Add timezone (TZ) support for container logs to match host machine timezone, making log comparison easier between host services and containers.

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔧 Refactor
- [ ] 📚 Documentation
- [ ] 🔒 Security fix

## Changes Made
- Add `TZ` environment variable to `docker-compose.dev.yml`
- Install `tzdata` package in panel Dockerfiles (Alpine requires it)
- Add `timezone` to backend config interface (reads from `TZ` env var)
- Dynamic servers now inherit timezone from panel configuration
- Document `TZ` variable in `.env.example`

## Testing
- [ ] Tested locally with `docker-compose -f docker-compose.dev.yml up --build`
- [ ] Tested panel login
- [ ] Tested affected features
  - [ ] Container logs show correct timezone
  - [ ] New servers inherit panel timezone

## Checklist
- [x] Code follows project patterns (see AGENTS.md)
- [ ] Translations updated if UI changed
- [x] .env.example updated if new variables
- [x] No console.log left in code
- [x] Both docker-compose files updated if needed

## Screenshots
<!-- N/A - no UI changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to passing a `TZ` env var through the dev compose and generated server compose, plus adding `tzdata` to images; no auth/data-flow logic changes beyond configuration wiring.
> 
> **Overview**
> Adds configurable timezone support so container logs can match the host timezone. The panel now reads `TZ` into backend config and uses it when generating per-server `docker-compose.yml`, while `docker-compose.dev.yml` passes `TZ` into the panel container.
> 
> Updates the panel Docker images to install `tzdata` (Alpine) and documents the new optional `TZ` variable in `.env.example`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d99b1a9c55e60259cd21d955242e7a53da014df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->