### PR TITLE
fix: recover backup scheduler from stalled operations and stale temp files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,3 +275,9 @@ docker build -t hytale-panel ./panel
 - Auto-downloader is **x64 only** (skipped on ARM64)
 - Server (Java) runs natively on ARM64
 - Users must manually copy `HytaleServer.jar` and `Assets.zip`
+
+## Version Source Of Truth
+
+- `config.json` is the canonical release version used by deployment/update flows.
+- For release-impacting changes, always bump `config.json.version`.
+- Keep package versions aligned when relevant (`panel/package.json`, `panel/backend/package.json`, `panel/frontend/package.json`), but `config.json` is the value that must never be skipped.

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.5.2",
+  "version": "1.5.3",
   "title": "HytalePanel",
   "description": "Docker image for Hytale dedicated server with optimized JVM settings"
 }

--- a/panel/backend/__tests__/backups-temp-recovery.test.ts
+++ b/panel/backend/__tests__/backups-temp-recovery.test.ts
@@ -1,0 +1,281 @@
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+const fsState = {
+  dirs: new Set<string>(),
+  files: new Map<string, string>(),
+  tempDirPath: '/tmp/hytale-backup-test',
+  mkdtempCalls: 0
+};
+
+const normalizePath = (input: string): string => input.replaceAll('\\', '/');
+const dirname = (input: string): string => normalizePath(path.posix.dirname(input));
+const basename = (input: string): string => path.posix.basename(normalizePath(input));
+
+const ensureDir = (input: string): void => {
+  const normalized = normalizePath(input);
+  if (!normalized || normalized === '.') return;
+  const segments = normalized.split('/').filter(Boolean);
+  let current = normalized.startsWith('/') ? '/' : '';
+  for (const segment of segments) {
+    current = current === '/' ? `/${segment}` : current ? `${current}/${segment}` : segment;
+    fsState.dirs.add(current);
+  }
+  if (normalized === '/') fsState.dirs.add('/');
+};
+
+const ensureDirForFile = (filePath: string): void => {
+  ensureDir(dirname(filePath));
+};
+
+const listDirEntries = (dirPath: string): string[] => {
+  const normalizedDir = normalizePath(dirPath).replace(/\/+$/, '');
+  const prefix = normalizedDir === '' ? '' : `${normalizedDir}/`;
+  const entries = new Set<string>();
+
+  for (const filePath of fsState.files.keys()) {
+    if (!filePath.startsWith(prefix)) continue;
+    const rest = filePath.slice(prefix.length);
+    if (!rest || rest.includes('/')) continue;
+    entries.add(rest);
+  }
+
+  for (const dir of fsState.dirs) {
+    if (!dir.startsWith(prefix) || dir === normalizedDir || dir === `${normalizedDir}/`) continue;
+    const rest = dir.slice(prefix.length).replace(/^\/+/, '');
+    if (!rest || rest.includes('/')) continue;
+    entries.add(rest);
+  }
+
+  return [...entries];
+};
+
+const fsPromisesMock = {
+  mkdtemp: jest.fn(async () => {
+    fsState.mkdtempCalls += 1;
+    const dir = `${fsState.tempDirPath}-${fsState.mkdtempCalls}`;
+    ensureDir(dir);
+    return dir;
+  }),
+  mkdir: jest.fn(async (dirPath: string) => {
+    ensureDir(dirPath);
+  }),
+  access: jest.fn(async (targetPath: string) => {
+    const normalized = normalizePath(targetPath);
+    if (!fsState.dirs.has(normalized) && !fsState.files.has(normalized)) {
+      const err = new Error('ENOENT') as NodeJS.ErrnoException;
+      err.code = 'ENOENT';
+      throw err;
+    }
+  }),
+  readdir: jest.fn(async (dirPath: string) => {
+    const normalized = normalizePath(dirPath);
+    if (!fsState.dirs.has(normalized)) {
+      const err = new Error('ENOENT') as NodeJS.ErrnoException;
+      err.code = 'ENOENT';
+      throw err;
+    }
+    return listDirEntries(normalized);
+  }),
+  writeFile: jest.fn(async (filePath: string, content: string | Buffer) => {
+    const normalized = normalizePath(filePath);
+    ensureDirForFile(normalized);
+    fsState.files.set(normalized, Buffer.isBuffer(content) ? content.toString('utf8') : String(content));
+  }),
+  readFile: jest.fn(async (filePath: string) => {
+    const normalized = normalizePath(filePath);
+    if (!fsState.files.has(normalized)) {
+      const err = new Error('ENOENT') as NodeJS.ErrnoException;
+      err.code = 'ENOENT';
+      throw err;
+    }
+    return fsState.files.get(normalized) as string;
+  }),
+  rename: jest.fn(async (fromPath: string, toPath: string) => {
+    const from = normalizePath(fromPath);
+    const to = normalizePath(toPath);
+    if (!fsState.files.has(from)) {
+      const err = new Error('ENOENT') as NodeJS.ErrnoException;
+      err.code = 'ENOENT';
+      throw err;
+    }
+    ensureDirForFile(to);
+    const value = fsState.files.get(from) as string;
+    fsState.files.delete(from);
+    fsState.files.set(to, value);
+  }),
+  unlink: jest.fn(async (filePath: string) => {
+    const normalized = normalizePath(filePath);
+    if (!fsState.files.has(normalized)) {
+      const err = new Error('ENOENT') as NodeJS.ErrnoException;
+      err.code = 'ENOENT';
+      throw err;
+    }
+    fsState.files.delete(normalized);
+  }),
+  rm: jest.fn(async (targetPath: string) => {
+    const normalized = normalizePath(targetPath);
+    fsState.files.delete(normalized);
+  }),
+  stat: jest.fn(async (filePath: string) => {
+    const normalized = normalizePath(filePath);
+    if (!fsState.files.has(normalized)) {
+      const err = new Error('ENOENT') as NodeJS.ErrnoException;
+      err.code = 'ENOENT';
+      throw err;
+    }
+    const size = (fsState.files.get(normalized) as string).length;
+    return { size } as { size: number };
+  })
+};
+
+const streamState = {
+  shouldErrorOutput: false
+};
+
+const createWriteStreamMock = jest.fn((targetPath: string) => {
+  const listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+  const normalized = normalizePath(targetPath);
+
+  const emit = (event: string, payload?: unknown): void => {
+    const fns = listeners.get(event) || [];
+    for (const fn of fns) {
+      fn(payload);
+    }
+  };
+
+  const stream = {
+    on: (event: string, cb: (...args: unknown[]) => void) => {
+      const current = listeners.get(event) || [];
+      current.push(cb);
+      listeners.set(event, current);
+      return stream;
+    },
+    destroy: (err?: Error) => {
+      if (err) emit('error', err);
+    },
+    __path: normalized,
+    __emitClose: () => emit('close')
+  };
+
+  return stream;
+});
+
+const archiverMockFactory = jest.fn(() => {
+  const listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+  let pipedStream: ReturnType<typeof createWriteStreamMock> | null = null;
+
+  const emit = (event: string, payload?: unknown): void => {
+    const fns = listeners.get(event) || [];
+    for (const fn of fns) fn(payload);
+  };
+
+  return {
+    pipe: (stream: ReturnType<typeof createWriteStreamMock>) => {
+      pipedStream = stream;
+    },
+    on: (event: string, cb: (...args: unknown[]) => void) => {
+      const current = listeners.get(event) || [];
+      current.push(cb);
+      listeners.set(event, current);
+    },
+    directory: () => undefined,
+    glob: () => undefined,
+    finalize: async () => {
+      if (!pipedStream) return;
+      if (streamState.shouldErrorOutput) {
+        emit('error', new Error('forced archive failure'));
+        pipedStream.destroy(new Error('forced output failure'));
+        return;
+      }
+      ensureDirForFile(pipedStream.__path);
+      fsState.files.set(pipedStream.__path, 'zip-content');
+      pipedStream.__emitClose();
+    },
+    abort: () => undefined
+  };
+});
+
+jest.unstable_mockModule('node:fs/promises', () => ({
+  default: fsPromisesMock,
+  ...fsPromisesMock
+}));
+
+jest.unstable_mockModule('node:fs', () => {
+  return {
+    createWriteStream: createWriteStreamMock
+  };
+});
+
+jest.unstable_mockModule('archiver', () => ({
+  default: archiverMockFactory
+}));
+
+jest.unstable_mockModule('extract-zip', () => ({
+  default: jest.fn(async () => undefined)
+}));
+
+jest.unstable_mockModule('../src/config/index.js', () => ({
+  default: {
+    data: {
+      path: '/tmp/hytale-backup-test'
+    }
+  }
+}));
+
+const { createBackup, listBackups } = await import('../src/services/backups.js');
+
+describe('Backups temp recovery', () => {
+  const serverId = 'srv-temp-recovery';
+  const backupsDir = `/tmp/hytale-backup-test/servers/${serverId}/backups`;
+  const serverDir = `/tmp/hytale-backup-test/servers/${serverId}/server`;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    streamState.shouldErrorOutput = false;
+    fsState.files.clear();
+    fsState.dirs.clear();
+    fsState.mkdtempCalls = 0;
+
+    ensureDir('/tmp');
+    ensureDir('/tmp/hytale-backup-test');
+    ensureDir('/tmp/hytale-backup-test/servers');
+    ensureDir(`/tmp/hytale-backup-test/servers/${serverId}`);
+    ensureDir(backupsDir);
+    ensureDir(serverDir);
+    ensureDir(`${serverDir}/universe`);
+    ensureDir(`${serverDir}/config`);
+    ensureDir(`${serverDir}/mods`);
+    ensureDir(`${serverDir}/logs`);
+  });
+
+  afterEach(() => {
+    streamState.shouldErrorOutput = false;
+  });
+
+  test('removes stale .tmp backups before creating a new backup', async () => {
+    const staleTemp = `${backupsDir}/backup-2026-03-09T08-11-56-171-3venkk.zip.tmp`;
+    fsState.files.set(staleTemp, 'stale-content');
+
+    const result = await createBackup(serverId);
+    expect(result.success).toBe(true);
+
+    const backups = await listBackups(serverId);
+    expect(backups.success).toBe(true);
+    expect(backups.backups.length).toBe(1);
+    expect(fsState.files.has(staleTemp)).toBe(false);
+  });
+
+  test('cleans temporary backup file when backup creation fails', async () => {
+    streamState.shouldErrorOutput = true;
+    const result = await createBackup(serverId);
+    expect(result.success).toBe(false);
+
+    const tempFiles = [...fsState.files.keys()].filter((entry) => entry.endsWith('.tmp'));
+    expect(tempFiles.length).toBe(0);
+
+    streamState.shouldErrorOutput = false;
+    const retryResult = await createBackup(serverId);
+    expect(retryResult.success).toBe(true);
+  });
+});

--- a/panel/backend/package.json
+++ b/panel/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hytale-panel-backend",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "main": "dist/server.js",

--- a/panel/backend/src/services/backups.ts
+++ b/panel/backend/src/services/backups.ts
@@ -58,6 +58,28 @@ export interface BackupConfigValidationResult {
 // Active schedulers map
 const activeSchedulers = new Map<string, NodeJS.Timeout>();
 const activeBackupOperations = new Set<string>();
+const BACKUP_CREATION_TIMEOUT_MS = 45 * 60 * 1000;
+
+function isTempBackupFile(fileName: string): boolean {
+  return /^backup-.*\.zip\.tmp$/i.test(fileName);
+}
+
+async function cleanupStaleTempBackups(serverId: string): Promise<void> {
+  const backupsDir = getBackupsDir(serverId);
+  const files = await fs.readdir(backupsDir).catch(() => []);
+  const tempFiles = files.filter(isTempBackupFile);
+  if (tempFiles.length === 0) return;
+
+  for (const tempFile of tempFiles) {
+    const tempPath = path.join(backupsDir, tempFile);
+    try {
+      await fs.unlink(tempPath);
+      console.warn(`[Backups] Removed stale temp backup: ${tempFile}`);
+    } catch (e) {
+      console.warn(`[Backups] Failed to remove stale temp backup ${tempFile}: ${(e as Error).message}`);
+    }
+  }
+}
 
 function getBackupsDir(serverId: string): string {
   return path.join(getServersDir(), serverId, 'backups');
@@ -222,12 +244,14 @@ export async function createBackup(serverId: string): Promise<BackupResult> {
   }
 
   activeBackupOperations.add(serverId);
+  let tempPath = '';
   try {
     const backupsDir = getBackupsDir(serverId);
     const serverDir = getServerDataDir(serverId);
 
     // Ensure backups directory exists
     await fs.mkdir(backupsDir, { recursive: true });
+    await cleanupStaleTempBackups(serverId);
 
     // Check if server directory exists
     try {
@@ -239,16 +263,36 @@ export async function createBackup(serverId: string): Promise<BackupResult> {
     const filename = generateBackupFilename();
     const backupPath = path.join(backupsDir, filename);
     const tempFilename = `${filename}.tmp`;
-    const tempPath = path.join(backupsDir, tempFilename);
+    tempPath = path.join(backupsDir, tempFilename);
 
     // Create ZIP archive atomically: write to temp file then rename
     console.log(`[Backups] Creating backup (temp): ${tempPath}`);
     await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const complete = (): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        resolve();
+      };
+      const fail = (error: Error): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        reject(error);
+      };
+
       const output = createWriteStream(tempPath);
       const archive = archiver('zip', { zlib: { level: 6 } });
+      const timeout = setTimeout(() => {
+        archive.abort();
+        output.destroy(new Error('backup creation timeout'));
+        fail(new Error('Backup creation timed out'));
+      }, BACKUP_CREATION_TIMEOUT_MS);
 
-      output.on('close', () => resolve());
-      archive.on('error', (err) => reject(err));
+      output.on('close', complete);
+      output.on('error', (err) => fail(err as Error));
+      archive.on('error', (err) => fail(err as Error));
 
       archive.pipe(output);
 
@@ -265,7 +309,7 @@ export async function createBackup(serverId: string): Promise<BackupResult> {
       archive.glob('*.yml', { cwd: serverDir });
       archive.glob('*.properties', { cwd: serverDir });
 
-      archive.finalize();
+      void archive.finalize();
     });
 
     // Move temp file to final name atomically
@@ -304,6 +348,9 @@ export async function createBackup(serverId: string): Promise<BackupResult> {
 
     return { success: true, backup };
   } catch (e) {
+    if (tempPath) {
+      await fs.rm(tempPath, { force: true }).catch(() => undefined);
+    }
     return { success: false, error: (e as Error).message };
   } finally {
     activeBackupOperations.delete(serverId);
@@ -593,13 +640,22 @@ export function startBackupScheduler(serverId: string, backupConfig: BackupConfi
   const intervalMs = backupConfig.intervalMinutes * 60 * 1000;
 
   const timer = setInterval(async () => {
-    console.log(`[Backups] Creating scheduled backup for ${serverId}`);
-    const result = await createBackup(serverId);
-    if (result.success) {
-      console.log(`[Backups] Scheduled backup created: ${result.backup?.filename}`);
-      await cleanupOldBackups(serverId, backupConfig);
-    } else {
-      console.error(`[Backups] Scheduled backup failed: ${result.error}`);
+    if (activeBackupOperations.has(serverId)) {
+      console.log(`[Backups] Skipping scheduled backup for ${serverId}: previous backup still in progress`);
+      return;
+    }
+
+    try {
+      console.log(`[Backups] Creating scheduled backup for ${serverId}`);
+      const result = await createBackup(serverId);
+      if (result.success) {
+        console.log(`[Backups] Scheduled backup created: ${result.backup?.filename}`);
+        await cleanupOldBackups(serverId, backupConfig);
+      } else {
+        console.error(`[Backups] Scheduled backup failed: ${result.error}`);
+      }
+    } catch (e) {
+      console.error(`[Backups] Scheduler error for ${serverId}:`, (e as Error).message);
     }
   }, intervalMs);
 

--- a/panel/frontend/package.json
+++ b/panel/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hytale-panel-frontend",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/panel/package.json
+++ b/panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hytale-panel",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- harden backup creation flow with explicit output stream error handling and timeout guard to avoid stuck "in progress" state
- remove stale `.zip.tmp` files before creating a new backup, and always clean temp files on backup failure
- update scheduler loop to skip overlapping runs safely and keep scheduler alive on unexpected errors
- add regression tests for stale temp recovery and failed backup cleanup behavior
- bump versions to `1.0.1` in panel manifests

## Why
Issue #80 reports intermittent backup stalls where a leftover `.tmp` file appears and later backups fail with "backup already in progress". This change ensures failed or interrupted backup attempts do not permanently block future scheduled/manual backups.

## Testing
- `cd panel/backend && pnpm test -- backups-temp-recovery.test.ts backups-cleanup.test.ts backups-stability.test.ts backups-atomic-delete.test.ts backups-rename-fallback.test.ts`
- `cd panel/backend && pnpm lint && pnpm check`
- `cd panel && pnpm lint && pnpm check`